### PR TITLE
Revert Python Version in Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0-slim-buster
+FROM python:3.9.6-slim-buster
 
 ENV APP_DIR=/opt/app
 


### PR DESCRIPTION
Apparently this broke the Docker container (and was not caught by tests, which only cover Python 3.7-9)